### PR TITLE
fix: disable background check for completion cmd

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -83,7 +83,6 @@ example sub "multi-word quoted string" --flag "another quoted string"
 		context.Background(),
 		cmd,
 		fang.WithoutManpage(),
-		fang.WithoutCompletions(),
 	); err != nil {
 		os.Exit(1)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -83,6 +83,7 @@ example sub "multi-word quoted string" --flag "another quoted string"
 		context.Background(),
 		cmd,
 		fang.WithoutManpage(),
+		fang.WithoutCompletions(),
 	); err != nil {
 		os.Exit(1)
 	}

--- a/fang.go
+++ b/fang.go
@@ -161,9 +161,9 @@ func getKey(info *debug.BuildInfo, key string) string {
 }
 
 func isDark() bool {
-	if len(os.Args) > 1 && os.Args[1] != "completion" {
-		return lipgloss.HasDarkBackground(os.Stdin, os.Stderr)
+	if len(os.Args) > 1 && os.Args[1] == "completion" {
+		return false
 	}
 
-	return false
+	return lipgloss.HasDarkBackground(os.Stdin, os.Stderr)
 }

--- a/fang.go
+++ b/fang.go
@@ -86,8 +86,7 @@ func Execute(ctx context.Context, root *cobra.Command, options ...Option) error 
 	}
 
 	if opts.theme == nil {
-		isDark := lipgloss.HasDarkBackground(os.Stdin, os.Stderr)
-		t := DefaultTheme(isDark)
+		t := DefaultTheme(isDark())
 		opts.theme = &t
 	}
 
@@ -159,4 +158,12 @@ func getKey(info *debug.BuildInfo, key string) string {
 		}
 	}
 	return ""
+}
+
+func isDark() bool {
+	if len(os.Args) > 1 && os.Args[1] != "completion" {
+		return lipgloss.HasDarkBackground(os.Stdin, os.Stderr)
+	}
+
+	return false
 }


### PR DESCRIPTION
### Describe your changes
A common way to source completions from CLIs is using process subsitution like this:
```
source <(cli completion zsh)
```

This does however not work currently in fang, because it opens stdin to check background color.

To reproduce the issue:
```
# Enable completion in example:
sed -i -e '/fang.WithoutCompletions(),/d' example/main.go
cat <(go run ./example/main.go completion zsh)
```
This hangs forever.

The proposed fix just checks to see if the command we're executing is the completion command, in which case the style / background color does not matter anyways and it skips the check.

Another (probably better) way to fix this would be to detect if we're piping (if that's possible) and not open stdin in that case.

### Related issue/discussion:

### Checklist before requesting a review

- [x] I have read `CONTRIBUTING.md`
- [x] I have performed a self-review of my code