### PR TITLE
added 'fang.WithoutVersion' to skip built-in version handling

### DIFF
--- a/fang.go
+++ b/fang.go
@@ -31,6 +31,7 @@ type ColorSchemeFunc = func(lipgloss.LightDarkFunc) ColorScheme
 type settings struct {
 	completions bool
 	manpages    bool
+	skipVersion bool
 	version     string
 	commit      string
 	colorscheme ColorSchemeFunc
@@ -80,6 +81,13 @@ func WithVersion(version string) Option {
 	}
 }
 
+// WithoutVersion skips the `-v,--version` functionality
+func WithoutVersion() Option {
+	return func(s *settings) {
+		s.skipVersion = true
+	}
+}
+
 // WithCommit sets the commit SHA.
 func WithCommit(commit string) Option {
 	return func(s *settings) {
@@ -122,7 +130,9 @@ func Execute(ctx context.Context, root *cobra.Command, options ...Option) error 
 
 	root.SilenceUsage = true
 	root.SilenceErrors = true
-	root.Version = buildVersion(opts)
+	if !opts.skipVersion {
+		root.Version = buildVersion(opts)
+	}
 	root.SetHelpFunc(helpFunc)
 
 	if opts.manpages {


### PR DESCRIPTION
### Describe your changes
Added `fang.WithoutVersion` to skip the built-in version handling.

### Related issue/discussion: <insert link>
https://github.com/charmbracelet/fang/issues/54

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
