### PR TITLE
fix: windows: always enable VT processing on Windows

### DIFF
--- a/fang.go
+++ b/fang.go
@@ -123,6 +123,14 @@ func Execute(ctx context.Context, root *cobra.Command, options ...Option) error 
 		option(&opts)
 	}
 
+	// Enable VT processing on Windows, otherwise, ANSI escape sequences might not work on older
+	// Windows versions. This is a no-op on other platforms.
+	for _, w := range []io.Writer{root.OutOrStdout(), root.ErrOrStderr()} {
+		// if we can't enable VT processing, just ignore it and continue
+		// without it.
+		_ = enableVirtualTerminalProcessing(w)
+	}
+
 	helpFunc := func(c *cobra.Command, _ []string) {
 		w := colorprofile.NewWriter(c.OutOrStdout(), os.Environ())
 		helpFn(c, w, makeStyles(mustColorscheme(opts.colorscheme)))

--- a/fang_other.go
+++ b/fang_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package fang
+
+import (
+	"io"
+)
+
+func enableVirtualTerminalProcessing(io.Writer) error { return nil }

--- a/fang_windows.go
+++ b/fang_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+// +build windows
+
+package fang
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/charmbracelet/x/term"
+	"golang.org/x/sys/windows"
+)
+
+func enableVirtualTerminalProcessing(w io.Writer) error {
+	f, ok := w.(term.File)
+	if !ok || !term.IsTerminal(f.Fd()) {
+		return nil
+	}
+	var mode uint32
+	if err := windows.GetConsoleMode(windows.Handle(f.Fd()), &mode); err != nil {
+		return fmt.Errorf("error getting console mode: %w", err)
+	}
+
+	if err := windows.SetConsoleMode(windows.Handle(f.Fd()),
+		mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
+		return fmt.Errorf("error setting console mode: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Older versions of Windows might not enable VT processing by default, which can lead to ANSI escape sequences not being interpreted correctly. This change ensures that VT processing is enabled for both stdout and stderr when running on Windows.

Fixes: https://github.com/charmbracelet/crush/issues/1041
