### PR TITLE
feat: add WithHelpAppender option to extend help output

### DIFF
--- a/fang.go
+++ b/fang.go
@@ -21,18 +21,23 @@ const shaLen = 7
 // ErrorHandler handles an error, printing them to the given [io.Writer].
 type ErrorHandler = func(w io.Writer, styles Styles, err error)
 
+// HelpAppender is a callback that can append custom content to the help output.
+// It receives the writer, command, and styles to maintain consistent formatting.
+type HelpAppender = func(w *colorprofile.Writer, c *cobra.Command, styles Styles)
+
 // ColorSchemeFunc gets a [lipgloss.LightDarkFunc] and returns a [ColorScheme].
 type ColorSchemeFunc = func(lipgloss.LightDarkFunc) ColorScheme
 
 type settings struct {
-	completions bool
-	manpages    bool
-	skipVersion bool
-	version     string
-	commit      string
-	colorscheme ColorSchemeFunc
-	errHandler  ErrorHandler
-	signals     []os.Signal
+	completions  bool
+	manpages     bool
+	skipVersion  bool
+	version      string
+	commit       string
+	colorscheme  ColorSchemeFunc
+	errHandler   ErrorHandler
+	helpAppender HelpAppender
+	signals      []os.Signal
 }
 
 // Option changes fang settings.
@@ -98,6 +103,16 @@ func WithErrorHandler(handler ErrorHandler) Option {
 	}
 }
 
+// WithHelpAppender sets a callback that appends custom content to the help output.
+// The callback is invoked after fang renders the standard help content, allowing
+// users to add custom sections (e.g., environment variables, feedback instructions)
+// while maintaining fang's styling consistency.
+func WithHelpAppender(appender HelpAppender) Option {
+	return func(s *settings) {
+		s.helpAppender = appender
+	}
+}
+
 // WithNotifySignal sets the signals that should interrupt the execution of the
 // program.
 func WithNotifySignal(signals ...os.Signal) Option {
@@ -129,7 +144,7 @@ func Execute(ctx context.Context, root *cobra.Command, options ...Option) error 
 
 	helpFunc := func(c *cobra.Command, _ []string) {
 		w := colorprofile.NewWriter(c.OutOrStdout(), os.Environ())
-		helpFn(c, w, makeStyles(mustColorscheme(opts.colorscheme)))
+		helpFn(c, w, makeStyles(mustColorscheme(opts.colorscheme)), opts.helpAppender)
 	}
 
 	root.SilenceUsage = true

--- a/fang_test.go
+++ b/fang_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"charm.land/fang/v2"
+	"github.com/charmbracelet/colorprofile"
 	"github.com/charmbracelet/x/exp/golden"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -214,6 +215,23 @@ func TestSetup(t *testing.T) {
 			return cmd
 		}
 		exercise(t, mkroot)
+	})
+
+	t.Run("with help appender", func(t *testing.T) {
+		mkroot := func() *cobra.Command {
+			return &cobra.Command{
+				Use:   "simple",
+				Short: "Short help",
+			}
+		}
+		customAppender := func(w *colorprofile.Writer, c *cobra.Command, styles fang.Styles) {
+			_, _ = fmt.Fprintln(w, styles.Title.Render("environment"))
+			_, _ = fmt.Fprintf(w, "  %s  %s\n",
+				styles.Program.Flag.Render("APP_DEBUG"),
+				styles.FlagDescription.Render("Enable debug mode"),
+			)
+		}
+		doExercise(t, mkroot, []string{"--help"}, assertNoError, fang.WithHelpAppender(customAppender))
 	})
 
 	t.Run("with examples", func(t *testing.T) {

--- a/help.go
+++ b/help.go
@@ -39,7 +39,7 @@ var width = sync.OnceValue(func() int {
 	return min(w, 120)
 })
 
-func helpFn(c *cobra.Command, w *colorprofile.Writer, styles Styles) {
+func helpFn(c *cobra.Command, w *colorprofile.Writer, styles Styles, appender HelpAppender) {
 	writeLongShort(w, styles, cmp.Or(c.Long, c.Short))
 	usage := styleUsage(c, styles.Codeblock.Program, true)
 	examples := styleExamples(c, styles)
@@ -102,6 +102,11 @@ func helpFn(c *cobra.Command, w *colorprofile.Writer, styles Styles) {
 				}
 			}
 		})
+	}
+
+	// Call the custom help appender if provided
+	if appender != nil {
+		appender(w, c, styles)
 	}
 
 	_, _ = fmt.Fprintln(w)

--- a/testdata/TestSetup/with_help_appender.golden
+++ b/testdata/TestSetup/with_help_appender.golden
@@ -9,18 +9,13 @@
             
     completion [command]  Generate the autocompletion script for the specified shell
     help [command]        Help about any command
-    sub-cmd               A sub command
-               
-  FIRST GROUP  
-               
-    sub-cmd-2             A sub command
-                
-  SECOND GROUP  
-                
-    sub-cmd-3             A sub command
          
   FLAGS  
          
     -h --help             Help for simple
     -v --version          Version for simple
+               
+  ENVIRONMENT  
+               
+  APP_DEBUG  Enable debug mode
 


### PR DESCRIPTION
## Summary

Adds support for custom help sections through a new `WithHelpAppender` option, addressing issue #82.

This implementation follows **Option 1** from the issue discussion - providing a callback that runs after fang's standard help rendering. This allows users to append custom content (environment variables, feedback instructions, configuration details, etc.) while maintaining fang's styling consistency.

## Changes

- Added `HelpAppender` type - a callback function that receives the writer, command, and styles
- Added `WithHelpAppender()` option function following the existing option pattern
- Modified `helpFn` to invoke the appender callback (if provided) after rendering standard help content
- Added test coverage with golden file demonstrating the feature
- Fixed golden test file that had duplicate COMMANDS sections

## Example Usage

```go
customAppender := func(w *colorprofile.Writer, c *cobra.Command, styles fang.Styles) {
    fmt.Fprintln(w, styles.Title.Render("environment"))
    fmt.Fprintf(w, "  %s  %s\n",
        styles.Program.Flag.Render("APP_DEBUG"),
        styles.FlagDescription.Render("Enable debug logging"),
    )
}

fang.Execute(ctx, rootCmd, fang.WithHelpAppender(customAppender))
```

## Benefits

- ✅ Non-breaking change - fully backward compatible
- ✅ Follows existing option pattern
- ✅ Provides full access to writer and styles for consistent formatting
- ✅ Minimal code changes (~30 lines)
- ✅ Flexible - users control what content to add and how to format it

Resolves #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)